### PR TITLE
Allow providing response file for running non-interactively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 config/resolv.template
 config/client/
+config/response.txt
 resolv.conf
 /.idea/
 packages/*.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
     kmod \
     iptables \
     ca-certificates \
-    file
+    file \
+    gettext-base
 
 RUN mkdir /root/Install
 WORKDIR /root/Install

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ be routed via the VPN. For example:
 routes=(10.0.0.0/8)
 ```
 Additional routes are space separated (it is a normal bash array)
+* Optionally add a response file called `config/response.txt`. If present, the commands in this file will be read to work non-interactively. You will also be prompted separately to enter your password, which is then available as `$VPN_PASSWORD` in the response file. For example:
+```
+connect vpn.mycompany.com
+1
+vpn-username
+$VPN_PASSWORD
+y
+```
 
 ## To run
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,5 +9,11 @@ sysctl net.ipv4.conf.all.forwarding=1
 /start-traps.sh &
 
 /opt/cisco/anyconnect/bin/vpnagentd
-/opt/cisco/anyconnect/bin/vpn
 
+if [ -f /response.txt ]; then
+  cat /response.txt | envsubst '$VPN_PASSWORD' | /opt/cisco/anyconnect/bin/vpn -s && \
+  unset VPN_PASSWORD && \
+  tail -f /dev/null
+else
+  /opt/cisco/anyconnect/bin/vpn
+fi

--- a/start-vpn
+++ b/start-vpn
@@ -33,6 +33,22 @@ if [ ! -f config/client/private/*.key ]; then
   exit 1
 fi
 
+if [ -f config/response.txt ]; then
+  if ! grep -q '\$VPN_PASSWORD' config/response.txt; then
+    echo 'Please make sure to reference VPN_PASSWORD in config/response.txt'
+    exit 1
+  fi
+
+  echo -n 'VPN password: '
+  read -s VPN_PASSWORD
+  echo
+  export VPN_PASSWORD
+
+  MOUNT_RESPONSE_FILE="-e VPN_PASSWORD -v $(pwd)/config/response.txt:/response.txt"
+else
+  MOUNT_RESPONSE_FILE=''
+fi
+
 . config/routes
 
 docker network ls | grep vpn-network > /dev/null
@@ -53,18 +69,22 @@ HAS_IMAGE=$?
 if [ $HAS_IMAGE -ne 0 ]; then
   echo "Creating docker image for VPN"
   docker build --tag vpn-anyconnect . 
+else
+  echo 'Updating Docker image...'
+  docker build -q --tag vpn-anyconnect . >/dev/null || exit 1
 fi
 
 echo "Starting VPN"
 
 mv /etc/resolv.conf /etc/resolv.conf.vpn-orig
 cp config/resolv.template /etc/resolv.conf
+chmod a+r /etc/resolv.conf
 
 for r in ${routes[@]}; do
   ip route add $r via 172.19.0.2
 done
 
-docker run --name vpn-anyconnect --privileged --cap-add NET_ADMIN --cap-add SYS_ADMIN -ti -v "$(pwd)/config/client":/root/.cisco/certificates/client --net vpn-network --ip 172.19.0.2 --rm vpn-anyconnect
+docker run --name vpn-anyconnect --privileged --cap-add NET_ADMIN --cap-add SYS_ADMIN -ti -v "$(pwd)/config/client":/root/.cisco/certificates/client $MOUNT_RESPONSE_FILE --net vpn-network --ip 172.19.0.2 --rm vpn-anyconnect
 echo "Restoring original configuration"
 
 for r in ${routes[@]}; do


### PR DESCRIPTION
This allows users to provide a `config/response.txt` file with the commands to be used for connecting and logging in. If that file is not present, `start-vpn` should work as before.

I had to apt-install `gettext-base` so that the `envsubst` command is available for replacing the string `$VPN_PASSWORD` in the response file with the value of that environment variable (which is set after prompting the user for their password).

If the Docker image already exists, `start-vpn` will now still make a call to `docker build` which should be quick if nothing has changed (and I've added `-q` as it seemed appropriate). This is because existing users will need to rebuild their image to get the changes to `Dockerfile` and `entrypoint.sh`.

I also added a small bug fix

```
chmod a+r /etc/resolv.conf
```

to fix a problem on my machine caused by `config/resolv.template` not being world-readable.