### PR TITLE
A few minor improvements: use container as forwarding name server, remove (unneeded) handling of client cert etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ config/resolv.template
 config/systemd-resolved.template
 config/client/
 config/response.txt
+config/AnyConnectProfile.xml
 resolv.conf
 /.idea/
 packages/*.deb

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config/resolv.template
+config/systemd-resolved.template
 config/client/
 config/response.txt
 resolv.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
     iptables \
     ca-certificates \
     file \
-    gettext-base
+    gettext-base \
+    dnsmasq
 
 RUN mkdir /root/Install
 WORKDIR /root/Install

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
     ca-certificates \
     file \
     gettext-base \
+    libglib2.0-0 \
     dnsmasq
 
 RUN mkdir /root/Install

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ COPY docker/entrypoint.sh /entrypoint.sh
 COPY docker/fix-firewall.sh /fix-firewall.sh
 COPY docker/systemctl /sbin/systemctl
 COPY docker/start-traps.sh /start-traps.sh
-COPY docker/stop-traps.sh /stop-traps.sh
 
 RUN chmod +x /entrypoint.sh && \
     chmod +x /fix-firewall.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN yes | ./vpn_install.sh 2 > /dev/null
 
 RUN ln -sf /etc/ssl/certs/ca-certificates.crt /opt/.cisco/certificates/ca/ca-certificates.pem
 
+WORKDIR /root/Install/anyconnect/posture
+RUN ./posture_install.sh --no-license > /dev/null
+
 WORKDIR /root
 
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ RUN tar xzf anyconnect.tar.gz && \
 WORKDIR /root/Install/anyconnect/vpn
 RUN yes | ./vpn_install.sh 2 > /dev/null
 
-RUN mv /opt/.cisco/certificates/ca /opt/.cisco/certificates/ca.orig && \
-    ln -sf /etc/ssl/certs/ /opt/.cisco/certificates/ca
+RUN ln -sf /etc/ssl/certs/ca-certificates.crt /opt/.cisco/certificates/ca/ca-certificates.pem
 
 WORKDIR /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY docker/entrypoint.sh /entrypoint.sh
 COPY docker/fix-firewall.sh /fix-firewall.sh
 COPY docker/systemctl /sbin/systemctl
 COPY docker/start-traps.sh /start-traps.sh
+COPY docker/stop-traps.sh /stop-traps.sh
 
 RUN chmod +x /entrypoint.sh && \
     chmod +x /fix-firewall.sh && \

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ vpn-username
 $VPN_PASSWORD
 y
 ```
+* Further, it is also possible to provide an existing AnyConnect profile as config/AnyConnectProfile.xml. In that case, adjust your config/response.txt file accordingly.
 
 ## To run
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@ All configuration is performed in the `config/` directory
 
 * Obtain the AnyConnect linux installer program. Place in the file 'packages/anyconnect.tar.gz'
 * Obtain the "Traps/Cortex" debian linux installer. Place in the file 'packages/cortex.deb' directory. 
-* Create a config/resolv.template file containing the VPN's DNS configuration, for example:
+* Create a config/resolv.template file containing the IP address of the container as nameserver and optionally the search domains you want to use. The container will forward DNS queries to the nameservers provided by the VPN connection or in interactive mode when no connection is established yet to 8.8.8.8 (Google):
 ```
-domain mycompany.com
-nameserver 10.20.30.40
-nameserver 10.20.31.40
+nameserver 172.19.0.2
 search mycompany.com
 ```
 * Specify the routes you wish to forward through the VPN in the file config/routes. Only these routes will

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ All configuration is performed in the `config/` directory
 nameserver 172.19.0.2
 search mycompany.com
 ```
+Alternatively, if your system uses `systemd-resolved` for providing name resolution to local applications (check with `systemctl is-active systemd-resolved.service`) create a config/systemd-resolved.template file with the following format:
+
+```
+[Resolve]
+DNS=172.19.0.2
+Domains=mycompany.com ~.
+```
+
 * Specify the routes you wish to forward through the VPN in the file config/routes. Only these routes will
 be routed via the VPN. For example:
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ All configuration is performed in the `config/` directory
 nameserver 172.19.0.2
 search mycompany.com
 ```
-Alternatively, if your system uses `systemd-resolved` for providing name resolution to local applications (check with `systemctl is-active systemd-resolved.service`) create a config/systemd-resolved.template file with the following format:
+* Alternatively, if your system uses `systemd-resolved` for providing name resolution to local applications (check with `systemctl is-active systemd-resolved.service`) create a config/systemd-resolved.template file with the following format:
 
 ```
 [Resolve]

--- a/README.md
+++ b/README.md
@@ -4,18 +4,7 @@ script then routes selected network ranges to the VPN. Currently all DNS traffic
 
 ## To configure
 
-All configuration is performed in the config/ directory
-
-* Create a client directory structure that contains your public and private keys:
-```
-+config/client
-+-- <User ID>.pem
-+--private
-|  +-- <User ID>.key 
-|
-```
-
-These should be the same as the originally created keys for openconnect.
+All configuration is performed in the `config/` directory
 
 * Obtain the AnyConnect linux installer program. Place in the file 'packages/anyconnect.tar.gz'
 * Obtain the "Traps/Cortex" debian linux installer. Place in the file 'packages/cortex.deb' directory. 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,8 +15,7 @@ service dnsmasq start
 if [ -f /response.txt ]; then
   cat /response.txt | envsubst '$VPN_PASSWORD' | /opt/cisco/anyconnect/bin/vpn -s && \
   unset VPN_PASSWORD && \
-  /stop-traps.sh && \
-  echo "Enjoy your VPN connection!"
+  echo "Enjoy your VPN connection!" && \
   tail -f /dev/null
 else
   /opt/cisco/anyconnect/bin/vpn

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,7 @@ sysctl net.ipv4.conf.all.forwarding=1
 if [ -f /response.txt ]; then
   cat /response.txt | envsubst '$VPN_PASSWORD' | /opt/cisco/anyconnect/bin/vpn -s && \
   unset VPN_PASSWORD && \
+  /stop-traps.sh && \
   tail -f /dev/null
 else
   /opt/cisco/anyconnect/bin/vpn

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,8 @@ sysctl net.ipv4.conf.all.forwarding=1
 /fix-firewall.sh &
 /start-traps.sh &
 
+service dnsmasq start
+
 /opt/cisco/anyconnect/bin/vpnagentd
 
 if [ -f /response.txt ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,6 +14,7 @@ if [ -f /response.txt ]; then
   cat /response.txt | envsubst '$VPN_PASSWORD' | /opt/cisco/anyconnect/bin/vpn -s && \
   unset VPN_PASSWORD && \
   /stop-traps.sh && \
+  echo "Enjoy your VPN connection!"
   tail -f /dev/null
 else
   /opt/cisco/anyconnect/bin/vpn

--- a/docker/fix-firewall.sh
+++ b/docker/fix-firewall.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 keep_forwarding_clear() {
-	iptables -L FORWARD | grep ciscovpn > /dev/null
+	iptables -w -L FORWARD | grep ciscovpn > /dev/null
 	FOUND=$?
 
 	if [ $FOUND -eq 0 ] ; then
 	    echo Flushing forwarding restrictions
-	    iptables -F FORWARD
+	    iptables -w -F FORWARD
 	    echo Setting up masquarade
-	    iptables -t nat -D POSTROUTING -o cscotun0 -j MASQUERADE > /dev/null
-	    iptables -t nat -A POSTROUTING -o cscotun0 -j MASQUERADE
+	    iptables -w -t nat -D POSTROUTING -o cscotun0 -j MASQUERADE > /dev/null
+	    iptables -w -t nat -A POSTROUTING -o cscotun0 -j MASQUERADE
 	fi
 }
 

--- a/docker/stop-traps.sh
+++ b/docker/stop-traps.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+echo "Stopping Traps..."
+pkill -9 authorized
+pkill -9 pmd
+echo Done

--- a/docker/stop-traps.sh
+++ b/docker/stop-traps.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-echo "Stopping Traps..."
-pkill -9 authorized
-pkill -9 pmd
-echo Done

--- a/start-vpn
+++ b/start-vpn
@@ -41,9 +41,11 @@ if [ -f config/response.txt ]; then
     exit 1
   fi
 
-  echo -n 'VPN password: '
-  read -sr VPN_PASSWORD
-  echo
+  while [ -z $VPN_PASSWORD ]; do
+    echo -n 'VPN password: '
+    read -sr VPN_PASSWORD
+    echo
+  done
   export VPN_PASSWORD
 
   MOUNT_RESPONSE_FILE="-e VPN_PASSWORD -v $(pwd)/config/response.txt:/response.txt"

--- a/start-vpn
+++ b/start-vpn
@@ -53,6 +53,11 @@ else
   MOUNT_RESPONSE_FILE=''
 fi
 
+if [ -f config/AnyConnectProfile.xml ]; then
+  MOUNT_ANYCONNECT_PROFILE="-v $(pwd)/config/AnyConnectProfile.xml:/opt/cisco/anyconnect/profile/AnyConnectProfile.xml"
+else
+  MOUNT_ANYCONNECT_PROFILE=''
+fi
 . config/routes
 
 "$DOCKER" network ls | grep vpn-network > /dev/null
@@ -94,7 +99,7 @@ for r in ${routes[@]}; do
   ip route add $r via 172.19.0.2
 done
 
-"$DOCKER" run --name vpn-anyconnect --privileged --cap-add NET_ADMIN --cap-add SYS_ADMIN -ti $MOUNT_RESPONSE_FILE --net vpn-network --ip 172.19.0.2 --rm vpn-anyconnect
+"$DOCKER" run --name vpn-anyconnect --privileged --cap-add NET_ADMIN --cap-add SYS_ADMIN -ti $MOUNT_RESPONSE_FILE $MOUNT_ANYCONNECT_PROFILE --net vpn-network --ip 172.19.0.2 --rm vpn-anyconnect
 echo "Restoring original configuration"
 
 for r in ${routes[@]}; do

--- a/start-vpn
+++ b/start-vpn
@@ -41,7 +41,7 @@ if [ -f config/response.txt ]; then
     exit 1
   fi
 
-  while [ -z $VPN_PASSWORD ]; do
+  while [ -z "$VPN_PASSWORD" ]; do
     echo -n 'VPN password: '
     read -sr VPN_PASSWORD
     echo

--- a/start-vpn
+++ b/start-vpn
@@ -24,7 +24,13 @@ if [ ! -f packages/cortex.deb ]; then
   exit 1
 fi
 
-if [ ! -f config/resolv.template ]; then
+if systemctl -q is-active systemd-resolved.service 2>/dev/null; then
+  if [ ! -f config/systemd-resolved.template ]; then
+    echo "Please create a systemd-resolved config template and place it in file config/systemd-resolved.template"
+    exit 1
+  fi
+  USE_SYSTEMD_RESOLVED=true
+elif [ ! -f config/resolv.template ]; then
   echo "Please create a resolve.conf template and place it in file config/resolv.template"
   exit 1
 fi
@@ -72,9 +78,15 @@ fi
 
 echo "Starting VPN"
 
-mv /etc/resolv.conf /etc/resolv.conf.vpn-orig
-cp config/resolv.template /etc/resolv.conf
-chmod a+r /etc/resolv.conf
+if [ -z $USE_SYSTEMD_RESOLVED ]; then
+  mv /etc/resolv.conf /etc/resolv.conf.vpn-orig
+  cp config/resolv.template /etc/resolv.conf
+  chmod a+r /etc/resolv.conf
+else
+  mkdir -p /etc/systemd/resolved.conf.d/
+  cp config/systemd-resolved.template /etc/systemd/resolved.conf.d/anyconnect-dns-settings.conf
+  systemctl restart systemd-resolved.service
+fi
 
 for r in ${routes[@]}; do
   ip route add $r via 172.19.0.2
@@ -87,4 +99,9 @@ for r in ${routes[@]}; do
   ip route del $r via 172.19.0.2
 done
 
-mv /etc/resolv.conf.vpn-orig /etc/resolv.conf
+if [ -z $USE_SYSTEMD_RESOLVED ]; then
+  mv /etc/resolv.conf.vpn-orig /etc/resolv.conf
+else
+  rm /etc/systemd/resolved.conf.d/anyconnect-dns-settings.conf
+  systemctl restart systemd-resolved.service
+fi

--- a/start-vpn
+++ b/start-vpn
@@ -29,16 +29,6 @@ if [ ! -f config/resolv.template ]; then
   exit 1
 fi
 
-if [ ! -f config/client/*.pem ]; then
-  echo "Please place your public VPN key in config/client directory"
-  exit 1
-fi
-
-if [ ! -f config/client/private/*.key ]; then
-  echo "Please place your private VPN key in config/client/private directory"
-  exit 1
-fi
-
 if [ -f config/response.txt ]; then
   if ! grep -q '\$VPN_PASSWORD' config/response.txt; then
     echo 'Please make sure to reference VPN_PASSWORD in config/response.txt'
@@ -90,7 +80,7 @@ for r in ${routes[@]}; do
   ip route add $r via 172.19.0.2
 done
 
-"$DOCKER" run --name vpn-anyconnect --privileged --cap-add NET_ADMIN --cap-add SYS_ADMIN -ti -v "$(pwd)/config/client":/root/.cisco/certificates/client $MOUNT_RESPONSE_FILE --net vpn-network --ip 172.19.0.2 --rm vpn-anyconnect
+"$DOCKER" run --name vpn-anyconnect --privileged --cap-add NET_ADMIN --cap-add SYS_ADMIN -ti $MOUNT_RESPONSE_FILE --net vpn-network --ip 172.19.0.2 --rm vpn-anyconnect
 echo "Restoring original configuration"
 
 for r in ${routes[@]}; do

--- a/start-vpn
+++ b/start-vpn
@@ -76,6 +76,14 @@ mv /etc/resolv.conf /etc/resolv.conf.vpn-orig
 cp config/resolv.template /etc/resolv.conf
 chmod a+r /etc/resolv.conf
 
+restart_systemd_resolved() {
+  # Restart systemd-resolved service if it is present and active
+  if systemctl -q is-active systemd-resolved.service 2>/dev/null; then
+    systemctl restart systemd-resolved.service;
+  fi
+}
+restart_systemd_resolved
+
 for r in ${routes[@]}; do
   ip route add $r via 172.19.0.2
 done
@@ -88,3 +96,4 @@ for r in ${routes[@]}; do
 done
 
 mv /etc/resolv.conf.vpn-orig /etc/resolv.conf
+restart_systemd_resolved

--- a/start-vpn
+++ b/start-vpn
@@ -76,14 +76,6 @@ mv /etc/resolv.conf /etc/resolv.conf.vpn-orig
 cp config/resolv.template /etc/resolv.conf
 chmod a+r /etc/resolv.conf
 
-restart_systemd_resolved() {
-  # Restart systemd-resolved service if it is present and active
-  if systemctl -q is-active systemd-resolved.service 2>/dev/null; then
-    systemctl restart systemd-resolved.service;
-  fi
-}
-restart_systemd_resolved
-
 for r in ${routes[@]}; do
   ip route add $r via 172.19.0.2
 done
@@ -96,4 +88,3 @@ for r in ${routes[@]}; do
 done
 
 mv /etc/resolv.conf.vpn-orig /etc/resolv.conf
-restart_systemd_resolved


### PR DESCRIPTION
- Use container as forwarding name server (dnsmasq) to avoid DNS errors in "interactive mode" (before connection is established)
- Make use of systemd-resolved functionality and don't override `/etc/resolv.conf` when this service is active
- Remove (unneeded) handling of client cert
- Add support for providing an existing AnyConnect profile file
